### PR TITLE
Chore: remove codacy check from pull.

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,9 +1,6 @@
 name: Codacy CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Codacy will now not be triggered on commits pushed to main, and only show up in pull requests. Codacy-related issues must be fixed on pull requests, so having it checked in main is redundant.