### PR TITLE
Delete the code related to transforming uvls when they are downloaded (incidencia)

### DIFF
--- a/app/modules/flamapy/routes.py
+++ b/app/modules/flamapy/routes.py
@@ -71,21 +71,6 @@ def valid(file_id):
     return jsonify({"success": True, "file_id": file_id})
 
 
-@flamapy_bp.route('/flamapy/to_glencoe/<int:file_id>', methods=['GET'])
-def to_glencoe(file_id):
-    temp_file = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
-    try:
-        hubfile = HubfileService().get_or_404(file_id)
-        fm = UVLReader(hubfile.get_path()).transform()
-        GlencoeWriter(temp_file.name, fm).transform()
-
-        # Return the file in the response
-        return send_file(temp_file.name, as_attachment=True, download_name=f'{hubfile.name}_glencoe.txt')
-    finally:
-        # Clean up the temporary file
-        os.remove(temp_file.name)
-
-
 @flamapy_bp.route('/flamapy/to_splot/<int:file_id>', methods=['GET'])
 def to_splot(file_id):
     temp_file = tempfile.NamedTemporaryFile(suffix='.splx', delete=False)

--- a/app/modules/flamapy/routes.py
+++ b/app/modules/flamapy/routes.py
@@ -69,18 +69,3 @@ def check_uvl(file_id):
 @flamapy_bp.route('/flamapy/valid/<int:file_id>', methods=['GET'])
 def valid(file_id):
     return jsonify({"success": True, "file_id": file_id})
-
-@flamapy_bp.route('/flamapy/to_cnf/<int:file_id>', methods=['GET'])
-def to_cnf(file_id):
-    temp_file = tempfile.NamedTemporaryFile(suffix='.cnf', delete=False)
-    try:
-        hubfile = HubfileService().get_by_id(file_id)
-        fm = UVLReader(hubfile.get_path()).transform()
-        sat = FmToPysat(fm).transform()
-        DimacsWriter(temp_file.name, sat).transform()
-
-        # Return the file in the response
-        return send_file(temp_file.name, as_attachment=True, download_name=f'{hubfile.name}_cnf.txt')
-    finally:
-        # Clean up the temporary file
-        os.remove(temp_file.name)

--- a/app/modules/flamapy/routes.py
+++ b/app/modules/flamapy/routes.py
@@ -70,22 +70,6 @@ def check_uvl(file_id):
 def valid(file_id):
     return jsonify({"success": True, "file_id": file_id})
 
-
-@flamapy_bp.route('/flamapy/to_splot/<int:file_id>', methods=['GET'])
-def to_splot(file_id):
-    temp_file = tempfile.NamedTemporaryFile(suffix='.splx', delete=False)
-    try:
-        hubfile = HubfileService().get_by_id(file_id)
-        fm = UVLReader(hubfile.get_path()).transform()
-        SPLOTWriter(temp_file.name, fm).transform()
-
-        # Return the file in the response
-        return send_file(temp_file.name, as_attachment=True, download_name=f'{hubfile.name}_splot.txt')
-    finally:
-        # Clean up the temporary file
-        os.remove(temp_file.name)
-
-
 @flamapy_bp.route('/flamapy/to_cnf/<int:file_id>', methods=['GET'])
 def to_cnf(file_id):
     temp_file = tempfile.NamedTemporaryFile(suffix='.cnf', delete=False)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed three API endpoints that were handling UVL file format conversions:
  - `/flamapy/to_glencoe` - UVL to Glencoe JSON conversion
  - `/flamapy/to_splot` - UVL to SPLOT conversion 
  - `/flamapy/to_cnf` - UVL to CNF conversion
- These transformations are now handled differently in the system
- Changes simplify the codebase and improve maintainability by removing redundant conversion logic



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Remove UVL format conversion endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/flamapy/routes.py

<li>Removed route '/flamapy/to_glencoe' that converted UVL files to <br>Glencoe JSON format<br> <li> Removed route '/flamapy/to_splot' that converted UVL files to SPLOT <br>format<br> <li> Removed route '/flamapy/to_cnf' that converted UVL files to CNF format<br> <br>


</details>


  </td>
  <td><a href="https://github.com/davidgonmar/uvlhub-egc/pull/195/files#diff-57d76a272c0fbd16fa4a8ce19929e33c8520625396de3b172cf87e749cd5a279">+0/-46</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information