### PR TITLE
CI dockerhub image

### DIFF
--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -10,8 +10,12 @@
 name: Publish image in Docker Hub
 
 on:
-  release:
-    types: [published]
+  pull request:
+    types: [closed]
+    branches:
+      - main
+      - build
+      - g2/task_52/test_workflow
 
 jobs:
   push_to_registry:
@@ -28,16 +32,16 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        run: docker build --build-arg VERSION_TAG=${{ github.event.release.tag_name }} -t drorganvidez/uvlhub:${{ github.event.release.tag_name }} -f docker/images/Dockerfile.prod .
+        run: docker build -t davidgonmar/uvlhub-egc:v1.0 -f docker/images/Dockerfile.prod .
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
 
       - name: Push Docker image to Docker Hub
-        run: docker push drorganvidez/uvlhub:${{ github.event.release.tag_name }}
+        run: docker push davidgonmar/uvlhub-egc:v1.0
 
       - name: Tag and push latest
         run: |
-          docker tag drorganvidez/uvlhub:${{ github.event.release.tag_name }} drorganvidez/uvlhub:latest
-          docker push drorganvidez/uvlhub:latest
+          docker tag davidgonmar/uvlhub-egc:v1.0 davidgonmar/uvlhub-egc:latest
+          docker push davidgonmar/uvlhub-egc:latest
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -32,16 +32,16 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        run: docker build -t davidgonmar/uvlhub-egc:v1.0 -f docker/images/Dockerfile.prod .
+        run: docker build -t cargarmar18/uvlhub-egc:v1.0 -f docker/images/Dockerfile.prod .
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
 
       - name: Push Docker image to Docker Hub
-        run: docker push davidgonmar/uvlhub-egc:v1.0
+        run: docker push cargarmar18/uvlhub-egc:v1.0
 
       - name: Tag and push latest
         run: |
-          docker tag davidgonmar/uvlhub-egc:v1.0 davidgonmar/uvlhub-egc:latest
-          docker push davidgonmar/uvlhub-egc:latest
+          docker tag cargarmar18/uvlhub-egc:v1.0 cargarmar18/uvlhub-egc:latest
+          docker push cargarmar18/uvlhub-egc:latest
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -10,7 +10,7 @@
 name: Publish image in Docker Hub
 
 on:
-  pull request:
+  pull_request:
     types: [closed]
     branches:
       - main

--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - main
       - build
-      - g2/task_52/test_workflow
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
### **User description**
Image update when pull request closes dockerhub workflow.


___

### **PR Type**
Enhancement


___

### **Description**
- Modified GitHub Actions workflow to trigger on PR merge instead of releases
- Updated Docker Hub repository configuration:
  - Changed repository from `drorganvidez/uvlhub` to `cargarmar18/uvlhub-egc`
  - Set fixed version tag `v1.0` instead of using release tag
- Added branch filters to only run on merges to `main` and `build` branches
- Updated Docker image tagging and pushing commands to use new repository



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment_on_dockerhub.yml</strong><dd><code>Update Docker Hub deployment workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deployment_on_dockerhub.yml

<li>Changed trigger from release events to PR closed events on main/build <br>branches<br> <li> Updated Docker image name from drorganvidez/uvlhub to <br>cargarmar18/uvlhub-egc<br> <li> Removed version tag argument and set fixed v1.0 tag<br> <li> Updated tagging and pushing of latest image with new repository name<br>


</details>


  </td>
  <td><a href="https://github.com/davidgonmar/uvlhub-egc/pull/228/files#diff-ad98de20264755803ba4456ccee5783966f799791855ab4e2b46ab8dad62c761">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information