### PR TITLE
Resolve the deletion issue with duplicate UVL file names

### DIFF
--- a/app/modules/dataset/templates/dataset/upload_dataset.html
+++ b/app/modules/dataset/templates/dataset/upload_dataset.html
@@ -259,6 +259,8 @@
 
                                 show_upload_dataset();
 
+                                file.newName = response.filename;
+
                                 console.log("File uploaded: ", response);
                                 // actions when UVL model is uploaded
                                 let listItem = document.createElement('li');
@@ -356,7 +358,7 @@
 
                                         }
                                     };
-                                    xhr.send(JSON.stringify({file: file.name}));
+                                    xhr.send(JSON.stringify({file: file.newName}));
                                 }.bind(this));
 
                                 /*


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a critical bug in UVL file deletion where files with duplicate names were not being deleted correctly
- The system now tracks and uses backend-assigned unique filenames instead of original file names for deletion operations
- This ensures that the correct file instance is deleted when multiple files share the same original name
- Changes are implemented in the file upload success handler and deletion request logic



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upload_dataset.html</strong><dd><code>Fix UVL file deletion by using backend-assigned filenames</code></dd></summary>
<hr>

app/modules/dataset/templates/dataset/upload_dataset.html

<li>Added storage of backend-assigned filename (<code>newName</code>) to file object <br>after successful upload<br> <li> Modified deletion request to send backend-assigned filename instead of <br>original filename<br>


</details>


  </td>
  <td><a href="https://github.com/davidgonmar/uvlhub-egc/pull/244/files#diff-e8cd83ca9419d5fcb6a11d033a21faeb62ccd27c02254cf23895629dd2f041fc">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information